### PR TITLE
kernel: Setup LLVM environment variables for newer clang

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -186,8 +186,12 @@ ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     ifeq ($(KERNEL_CC),)
         KERNEL_CC := CC="$(CCACHE_BIN) clang"
     endif
-    ifeq ($(KERNEL_LD),)
-        KERNEL_LD :=
+    ifeq ($(TARGET_KERNEL_CLANG_VERSION),11)
+        KERNEL_CC += AR=llvm-ar
+        KERNEL_CC += NM=llvm-nm
+        KERNEL_CC += OBJCOPY=llvm-objcopy
+        KERNEL_CC += OBJDUMP=llvm-objdump
+        KERNEL_CC += STRIP=llvm-strip
     endif
 endif
 


### PR DESCRIPTION
These are must for custom toolchains with RELR Relocations to reduce reliance on binutils.

Signed-off-by: Panchajanya1999 <panchajanya@azure-dev.live>