### PR TITLE
kernel: Setup LLVM environment variables for newer clang

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -189,6 +189,13 @@ ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     ifeq ($(KERNEL_LD),)
         KERNEL_LD :=
     endif
+    ifeq ($(TARGET_KERNEL_CLANG_VERSION),11)
+        KERNEL_CC += AR=llvm-ar
+        KERNEL_CC += NM=llvm-nm
+        KERNEL_CC += OBJCOPY=llvm-objcopy
+        KERNEL_CC += OBJDUMP=llvm-objdump
+        KERNEL_CC += STRIP=llvm-strip
+    endif
 endif
 
 ifneq ($(TARGET_KERNEL_MODULES),)


### PR DESCRIPTION
These are must for custom toolchains with RELR Relocations to reduce reliance on binutils.

Signed-off-by: Panchajanya1999 <panchajanya@azure-dev.live>
Change-Id: I3e7223c5efb1740761b6ece6fc09b4232cb62a8c